### PR TITLE
Add session notes/descriptions

### DIFF
--- a/src/cli/spawn.rs
+++ b/src/cli/spawn.rs
@@ -21,7 +21,7 @@ fn branch_exists(git_root: &std::path::Path, branch_name: &str) -> bool {
         .unwrap_or(false)
 }
 
-pub async fn run(name: &str) -> Result<()> {
+pub async fn run(name: &str, note: Option<&str>) -> Result<()> {
     let current_dir = env::current_dir().context("Failed to get current directory")?;
     let git_root = worktree::find_git_root(&current_dir)?;
 
@@ -58,7 +58,13 @@ pub async fn run(name: &str) -> Result<()> {
     let tmux_session =
         session_manager.create(&project.name, &branch_name, &worktree_path, &config.setup)?;
 
-    db.add_session(project.id, &branch_name, &worktree_path, &tmux_session)?;
+    db.add_session(
+        project.id,
+        &branch_name,
+        &worktree_path,
+        &tmux_session,
+        note,
+    )?;
 
     println!("\nSession '{branch_name}' created. Attach with: mycel attach {branch_name}");
 

--- a/src/cli/unbank.rs
+++ b/src/cli/unbank.rs
@@ -54,7 +54,13 @@ pub async fn run(name: &str, spawn: bool, force: bool) -> Result<()> {
         let tmux_session =
             session_manager.create(&project.name, &branch_name, &worktree_path, &config.setup)?;
 
-        db.add_session(project.id, &branch_name, &worktree_path, &tmux_session)?;
+        db.add_session(
+            project.id,
+            &branch_name,
+            &worktree_path,
+            &tmux_session,
+            None,
+        )?;
 
         println!("\nSession '{name}' restored. Attach with: mycel attach {name}");
     } else {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -19,6 +19,7 @@ pub struct Session {
     pub name: String,
     pub worktree_path: PathBuf,
     pub tmux_session: String,
+    pub note: Option<String>,
     pub created_at_unix: i64,
 }
 
@@ -57,6 +58,7 @@ impl Database {
                 name TEXT NOT NULL,
                 worktree_path TEXT NOT NULL,
                 tmux_session TEXT NOT NULL,
+                note TEXT,
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY (project_id) REFERENCES projects(id),
                 UNIQUE(project_id, name)
@@ -65,6 +67,7 @@ impl Database {
         )?;
 
         self.ensure_sessions_created_at()?;
+        self.ensure_sessions_note()?;
         Ok(())
     }
 
@@ -84,6 +87,21 @@ impl Database {
                 "UPDATE sessions SET created_at = CURRENT_TIMESTAMP WHERE created_at IS NULL",
                 [],
             )?;
+        }
+
+        Ok(())
+    }
+
+    fn ensure_sessions_note(&self) -> Result<()> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'note'",
+            [],
+            |row| row.get(0),
+        )?;
+
+        if count == 0 {
+            self.conn
+                .execute("ALTER TABLE sessions ADD COLUMN note TEXT", [])?;
         }
 
         Ok(())
@@ -140,10 +158,17 @@ impl Database {
         name: &str,
         worktree_path: &Path,
         tmux_session: &str,
+        note: Option<&str>,
     ) -> Result<i64> {
         self.conn.execute(
-            "INSERT INTO sessions (project_id, name, worktree_path, tmux_session) VALUES (?1, ?2, ?3, ?4)",
-            params![project_id, name, worktree_path.to_string_lossy(), tmux_session],
+            "INSERT INTO sessions (project_id, name, worktree_path, tmux_session, note) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                project_id,
+                name,
+                worktree_path.to_string_lossy(),
+                tmux_session,
+                note
+            ],
         )?;
 
         Ok(self.conn.last_insert_rowid())
@@ -151,7 +176,7 @@ impl Database {
 
     pub fn get_session_by_name(&self, project_id: i64, name: &str) -> Result<Option<Session>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, name, worktree_path, tmux_session, CAST(strftime('%s', created_at) AS INTEGER)
+            "SELECT id, name, worktree_path, tmux_session, note, CAST(strftime('%s', created_at) AS INTEGER)
              FROM sessions WHERE project_id = ?1 AND name = ?2",
         )?;
 
@@ -161,7 +186,8 @@ impl Database {
                 name: row.get(1)?,
                 worktree_path: PathBuf::from(row.get::<_, String>(2)?),
                 tmux_session: row.get(3)?,
-                created_at_unix: row.get(4)?,
+                note: row.get(4)?,
+                created_at_unix: row.get(5)?,
             })
         });
 
@@ -174,7 +200,7 @@ impl Database {
 
     pub fn list_sessions(&self, project_id: i64) -> Result<Vec<Session>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, name, worktree_path, tmux_session, CAST(strftime('%s', created_at) AS INTEGER)
+            "SELECT id, name, worktree_path, tmux_session, note, CAST(strftime('%s', created_at) AS INTEGER)
              FROM sessions WHERE project_id = ?1",
         )?;
 
@@ -185,7 +211,8 @@ impl Database {
                     name: row.get(1)?,
                     worktree_path: PathBuf::from(row.get::<_, String>(2)?),
                     tmux_session: row.get(3)?,
-                    created_at_unix: row.get(4)?,
+                    note: row.get(4)?,
+                    created_at_unix: row.get(5)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -206,6 +233,15 @@ impl Database {
     pub fn delete_session(&self, session_id: i64) -> Result<()> {
         self.conn
             .execute("DELETE FROM sessions WHERE id = ?1", params![session_id])?;
+
+        Ok(())
+    }
+
+    pub fn update_session_note(&self, session_id: i64, note: Option<&str>) -> Result<()> {
+        self.conn.execute(
+            "UPDATE sessions SET note = ?1 WHERE id = ?2",
+            params![note, session_id],
+        )?;
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,9 @@ enum Commands {
     Spawn {
         /// Name for the worktree/session
         name: String,
+        /// Optional note for the session
+        #[arg(short, long)]
+        note: Option<String>,
     },
     /// Attach to an existing session
     Attach {
@@ -84,7 +87,7 @@ async fn main() -> Result<()> {
         None => tui::run().await,
         Some(Commands::Init) => cli::init::run().await,
         Some(Commands::Projects) => cli::projects::run().await,
-        Some(Commands::Spawn { name }) => cli::spawn::run(&name).await,
+        Some(Commands::Spawn { name, note }) => cli::spawn::run(&name, note.as_deref()).await,
         Some(Commands::Attach { name }) => cli::attach::run(&name).await,
         Some(Commands::List) => cli::list::run().await,
         Some(Commands::Kill {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -348,6 +348,17 @@ pub async fn run() -> Result<()> {
                                 let name = name.trim();
 
                                 if !name.is_empty() {
+                                    print!("Session note (optional): ");
+                                    io::stdout().flush()?;
+                                    let mut note = String::new();
+                                    io::stdin().read_line(&mut note)?;
+                                    let note = note.trim();
+                                    let note = if note.is_empty() {
+                                        None
+                                    } else {
+                                        Some(note.to_string())
+                                    };
+
                                     let config = ProjectConfig::load(&project.path)?;
                                     let sanitized = worktree::sanitize_branch_name(name);
 
@@ -390,10 +401,55 @@ pub async fn run() -> Result<()> {
                                         &branch_name,
                                         &worktree_path,
                                         &tmux_session,
+                                        note.as_deref(),
                                     )?;
                                     println!("Session '{branch_name}' created.");
                                     std::thread::sleep(std::time::Duration::from_millis(500));
                                 }
+
+                                enable_raw_mode()?;
+                                execute!(
+                                    terminal.backend_mut(),
+                                    EnterAlternateScreen,
+                                    EnableMouseCapture
+                                )?;
+                                terminal.clear()?;
+                                app.refresh()?;
+                            }
+                        }
+                        KeyCode::Char('n') => {
+                            if let Some(SelectedItem::Session(_, session)) = app.get_selected_item()
+                            {
+                                let session_id = session.session.id;
+                                let session_name = session.session.name.clone();
+                                let current_note =
+                                    session.session.note.clone().unwrap_or_default();
+
+                                disable_raw_mode()?;
+                                execute!(
+                                    terminal.backend_mut(),
+                                    LeaveAlternateScreen,
+                                    DisableMouseCapture
+                                )?;
+
+                                println!("Edit note for '{session_name}' (blank to clear):");
+                                if !current_note.is_empty() {
+                                    println!("Current: {current_note}");
+                                }
+                                print!("New note: ");
+                                io::stdout().flush()?;
+                                let mut note = String::new();
+                                io::stdin().read_line(&mut note)?;
+                                let note = note.trim();
+                                let note = if note.is_empty() {
+                                    None
+                                } else {
+                                    Some(note.to_string())
+                                };
+
+                                app.db.update_session_note(session_id, note.as_deref())?;
+                                println!("Note updated.");
+                                std::thread::sleep(std::time::Duration::from_millis(500));
 
                                 enable_raw_mode()?;
                                 execute!(
@@ -612,6 +668,7 @@ pub async fn run() -> Result<()> {
                                                 &branch_name,
                                                 &worktree_path,
                                                 &tmux_session,
+                                                None,
                                             )?;
 
                                             println!("Session '{item_name}' restored.");
@@ -770,7 +827,7 @@ fn draw_ui(f: &mut Frame, app: &App) {
                     Style::default().fg(Color::White)
                 };
 
-                let line = Line::from(vec![
+                let mut spans = vec![
                     Span::styled(format!("{prefix} "), Style::default().fg(Color::DarkGray)),
                     Span::styled(&session.session.name, session_style),
                     Span::raw("  "),
@@ -784,7 +841,20 @@ fn draw_ui(f: &mut Frame, app: &App) {
                         Style::default().fg(Color::DarkGray),
                     ),
                     Span::styled(format!("  {age}"), Style::default().fg(Color::DarkGray)),
-                ]);
+                ];
+
+                if let Some(note) = &session.session.note {
+                    let note = note.trim();
+                    if !note.is_empty() {
+                        let note = format_note_excerpt(note, 40);
+                        spans.push(Span::styled(
+                            format!("  - {note}"),
+                            Style::default().fg(Color::DarkGray),
+                        ));
+                    }
+                }
+
+                let line = Line::from(spans);
 
                 items.push(ListItem::new(line));
             }
@@ -843,7 +913,7 @@ fn draw_ui(f: &mut Frame, app: &App) {
         f.render_widget(list, chunks[1]);
     }
 
-    let mut footer_text = " [a]ttach  [s]pawn  [b]ank  [u]nbank  [x] kill  [r]efresh  [/] search  [q]uit".to_string();
+    let mut footer_text = " [a]ttach  [s]pawn  [n]ote  [b]ank  [u]nbank  [x] kill  [r]efresh  [/] search  [q]uit".to_string();
     if app.search_mode || !app.search_query.is_empty() {
         footer_text.push_str("  [esc] clear");
         if app.search_mode {
@@ -882,4 +952,19 @@ fn format_relative_age(created_at_unix: i64, now_unix: i64) -> String {
     } else {
         format!("{}w ago", age_secs / 604_800)
     }
+}
+
+fn format_note_excerpt(note: &str, max_len: usize) -> String {
+    if max_len <= 3 {
+        return note.chars().take(max_len).collect();
+    }
+
+    let mut chars = note.chars();
+    let mut excerpt: String = chars.by_ref().take(max_len).collect();
+    if chars.next().is_some() {
+        excerpt = excerpt.chars().take(max_len - 3).collect();
+        excerpt.push_str("...");
+    }
+
+    excerpt
 }


### PR DESCRIPTION
## Summary
- store optional session notes with a DB migration
- prompt for notes on spawn and edit via [n] in the TUI
- show note excerpts in the session list and add --note for CLI spawn

Closes #3