### PR TITLE
Add stop command and pause key for sessions

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,4 +7,5 @@ pub mod list;
 pub mod notify;
 pub mod projects;
 pub mod spawn;
+pub mod stop;
 pub mod unbank;

--- a/src/cli/stop.rs
+++ b/src/cli/stop.rs
@@ -1,0 +1,43 @@
+use anyhow::{Context, Result};
+use std::env;
+
+use crate::confirm;
+use crate::db::Database;
+use crate::session::SessionManager;
+use crate::worktree;
+
+pub async fn run(name: &str, force: bool) -> Result<()> {
+    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let git_root = worktree::find_git_root(&current_dir)?;
+
+    let db = Database::open()?;
+
+    let project = db
+        .get_project_by_path(&git_root)?
+        .context("Project not registered. Run 'mycel init' first.")?;
+
+    let session = db
+        .get_session_by_name(project.id, name)?
+        .context(format!("Session '{name}' not found"))?;
+
+    if !force {
+        let prompt = format!("Stop session '{name}'?");
+        if !confirm::prompt_confirm(&prompt)? {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    let session_manager = SessionManager::new();
+
+    if session_manager.is_alive(&session.tmux_session)? {
+        println!("Stopping session '{name}'...");
+        session_manager.kill(&session.tmux_session)?;
+    } else {
+        println!("Session '{name}' already stopped.");
+    }
+
+    println!("Worktree preserved at: {}", session.worktree_path.display());
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,14 @@ enum Commands {
         #[arg(long)]
         force: bool,
     },
+    /// Stop a session without removing its worktree
+    Stop {
+        /// Name of the session to stop
+        name: String,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        force: bool,
+    },
     /// Bank a completed session (bundle commits for later)
     Bank {
         /// Name of the session to bank
@@ -103,6 +111,7 @@ async fn main() -> Result<()> {
             remove,
             force,
         }) => cli::kill::run(&name, remove, force).await,
+        Some(Commands::Stop { name, force }) => cli::stop::run(&name, force).await,
         Some(Commands::Bank { name, keep, force }) => cli::bank::run(&name, keep, force).await,
         Some(Commands::Unbank { name, spawn, force }) => {
             cli::unbank::run(&name, spawn, force).await

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -330,8 +330,15 @@ pub async fn run() -> Result<()> {
                         KeyCode::Char('/') => app.search_mode = true,
                         KeyCode::Esc => app.clear_search(),
                         KeyCode::Char('a') => {
-                            if let Some(SelectedItem::Session(_, session)) = app.get_selected_item()
+                            if let Some(SelectedItem::Session(project, session)) =
+                                app.get_selected_item()
                             {
+                                let project_name = project.project.name.clone();
+                                let project_path = project.project.path.clone();
+                                let session_name = session.session.name.clone();
+                                let tmux_session = session.session.tmux_session.clone();
+                                let worktree_path = session.session.worktree_path.clone();
+
                                 // Restore terminal before attaching
                                 disable_raw_mode()?;
                                 execute!(
@@ -340,7 +347,18 @@ pub async fn run() -> Result<()> {
                                     DisableMouseCapture
                                 )?;
 
-                                app.session_manager.attach(&session.session.tmux_session)?;
+                                if !app.session_manager.is_alive(&tmux_session)? {
+                                    println!("Session '{session_name}' is not running. Restarting...");
+                                    let config = ProjectConfig::load(&project_path)?;
+                                    app.session_manager.create(
+                                        &project_name,
+                                        &session_name,
+                                        &worktree_path,
+                                        &config.setup,
+                                    )?;
+                                }
+
+                                app.session_manager.attach(&tmux_session)?;
 
                                 // Restore TUI after detaching
                                 enable_raw_mode()?;
@@ -480,6 +498,50 @@ pub async fn run() -> Result<()> {
                                 app.db.update_session_note(session_id, note.as_deref())?;
                                 println!("Note updated.");
                                 std::thread::sleep(std::time::Duration::from_millis(500));
+
+                                enable_raw_mode()?;
+                                execute!(
+                                    terminal.backend_mut(),
+                                    EnterAlternateScreen,
+                                    EnableMouseCapture
+                                )?;
+                                terminal.clear()?;
+                                app.refresh()?;
+                            }
+                        }
+                        KeyCode::Char('p') => {
+                            if let Some(SelectedItem::Session(_, session)) = app.get_selected_item()
+                            {
+                                let session_name = session.session.name.clone();
+                                let tmux_session = session.session.tmux_session.clone();
+                                let worktree_path = session.session.worktree_path.clone();
+
+                                disable_raw_mode()?;
+                                execute!(
+                                    terminal.backend_mut(),
+                                    LeaveAlternateScreen,
+                                    DisableMouseCapture
+                                )?;
+
+                                let prompt = format!("Stop session '{session_name}'?");
+                                let confirmed = confirm::prompt_confirm(&prompt)?;
+
+                                if confirmed {
+                                    if app.session_manager.is_alive(&tmux_session)? {
+                                        println!("Stopping session '{session_name}'...");
+                                        app.session_manager.kill(&tmux_session)?;
+                                    } else {
+                                        println!("Session '{session_name}' already stopped.");
+                                    }
+                                    println!(
+                                        "Worktree preserved at: {}",
+                                        worktree_path.display()
+                                    );
+                                    std::thread::sleep(std::time::Duration::from_millis(800));
+                                } else {
+                                    println!("Cancelled.");
+                                    std::thread::sleep(std::time::Duration::from_millis(500));
+                                }
 
                                 enable_raw_mode()?;
                                 execute!(
@@ -986,9 +1048,8 @@ fn draw_ui(f: &mut Frame, app: &App) {
         f.render_widget(list, chunks[1]);
     }
 
-    let mut footer_text =
-        " [a]ttach  [s]pawn  [n]ote  [b]ank  [u]nbank  [x] kill  [r]efresh  [/] search  [q]uit"
-            .to_string();
+    let mut footer_text = " [a]ttach  [s]pawn  [n]ote  [p]ause  [b]ank  [u]nbank  [x] kill  [r]efresh  [/] search  [q]uit"
+        .to_string();
     if app.search_mode || !app.search_query.is_empty() {
         footer_text.push_str("  [esc] clear");
         if app.search_mode {


### PR DESCRIPTION
## Summary
- add stop command to preserve worktrees
- restart stopped sessions when attaching from TUI
- add pause keybinding and footer hint

Closes #7