### PR TITLE
Add session templates for spawn

### DIFF
--- a/src/cli/spawn.rs
+++ b/src/cli/spawn.rs
@@ -1,8 +1,9 @@
 use anyhow::{bail, Context, Result};
 use std::env;
+use std::time::Duration;
 use std::process::Command;
 
-use crate::config::ProjectConfig;
+use crate::config::{ProjectConfig, TemplateConfig};
 use crate::db::Database;
 use crate::session::SessionManager;
 use crate::worktree;
@@ -21,7 +22,7 @@ fn branch_exists(git_root: &std::path::Path, branch_name: &str) -> bool {
         .unwrap_or(false)
 }
 
-pub async fn run(name: &str, note: Option<&str>) -> Result<()> {
+pub async fn run(name: &str, note: Option<&str>, template_name: Option<&str>) -> Result<()> {
     let current_dir = env::current_dir().context("Failed to get current directory")?;
     let git_root = worktree::find_git_root(&current_dir)?;
 
@@ -31,7 +32,18 @@ pub async fn run(name: &str, note: Option<&str>) -> Result<()> {
         .get_project_by_path(&git_root)?
         .context("Project not registered. Run 'mycel init' first.")?;
 
-    let sanitized_name = worktree::sanitize_branch_name(name);
+    let config = ProjectConfig::load(&git_root)?;
+    let template = match template_name {
+        Some(name) => Some(
+            config
+                .templates
+                .get(name)
+                .with_context(|| format!("Template '{name}' not found in .mycel.toml"))?,
+        ),
+        None => None,
+    };
+    let full_name = apply_template_prefix(name, template.and_then(|t| t.branch_prefix.as_deref()));
+    let sanitized_name = worktree::sanitize_branch_name(&full_name);
 
     if db
         .get_session_by_name(project.id, &sanitized_name)?
@@ -40,23 +52,22 @@ pub async fn run(name: &str, note: Option<&str>) -> Result<()> {
         bail!("Session '{sanitized_name}' already exists in this project");
     }
 
-    let config = ProjectConfig::load(&git_root)?;
-
     let (worktree_path, branch_name) = if branch_exists(&git_root, &sanitized_name) {
         println!("Using existing branch '{sanitized_name}'...");
         worktree::create_from_existing(&git_root, &sanitized_name, &config)?
     } else {
         println!("Creating worktree '{sanitized_name}'...");
-        worktree::create(&git_root, name, &config)?
+        worktree::create(&git_root, &full_name, &config)?
     };
 
     println!("Starting Claude session...");
-    if !config.setup.is_empty() {
-        println!("Setup: {}", config.setup.join(" && "));
+    let setup = merge_setup(&config, template);
+    if !setup.is_empty() {
+        println!("Setup: {}", setup.join(" && "));
     }
     let session_manager = SessionManager::new();
     let tmux_session =
-        session_manager.create(&project.name, &branch_name, &worktree_path, &config.setup)?;
+        session_manager.create(&project.name, &branch_name, &worktree_path, &setup)?;
 
     db.add_session(
         project.id,
@@ -66,7 +77,35 @@ pub async fn run(name: &str, note: Option<&str>) -> Result<()> {
         note,
     )?;
 
+    if let Some(prompt) = template
+        .and_then(|t| t.prompt.as_deref())
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+    {
+        std::thread::sleep(Duration::from_millis(600));
+        if let Err(err) = session_manager.send_prompt(&tmux_session, prompt) {
+            eprintln!("Warning: failed to send template prompt: {err}");
+        }
+    }
+
     println!("\nSession '{branch_name}' created. Attach with: mycel attach {branch_name}");
 
     Ok(())
+}
+
+fn apply_template_prefix(name: &str, prefix: Option<&str>) -> String {
+    match prefix {
+        Some(prefix) if !prefix.is_empty() && !name.starts_with(prefix) => {
+            format!("{prefix}{name}")
+        }
+        _ => name.to_string(),
+    }
+}
+
+fn merge_setup(config: &ProjectConfig, template: Option<&TemplateConfig>) -> Vec<String> {
+    let mut setup = config.setup.clone();
+    if let Some(template) = template {
+        setup.extend(template.setup.clone());
+    }
+    setup
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
@@ -58,6 +59,8 @@ pub struct ProjectConfig {
     pub worktree_dir: String,
     #[serde(default)]
     pub max_sessions: Option<u32>,
+    #[serde(default)]
+    pub templates: BTreeMap<String, TemplateConfig>,
 }
 
 fn default_base_branch() -> String {
@@ -75,6 +78,7 @@ impl Default for ProjectConfig {
             setup: Vec::new(),
             worktree_dir: default_worktree_dir(),
             max_sessions: None,
+            templates: BTreeMap::new(),
         }
     }
 }
@@ -91,4 +95,14 @@ impl ProjectConfig {
 
         toml::from_str(&content).context("Failed to parse project config")
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TemplateConfig {
+    #[serde(default)]
+    pub branch_prefix: Option<String>,
+    #[serde(default)]
+    pub setup: Vec<String>,
+    #[serde(default)]
+    pub prompt: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,9 @@ enum Commands {
         /// Optional note for the session
         #[arg(short, long)]
         note: Option<String>,
+        /// Optional session template name
+        #[arg(short, long)]
+        template: Option<String>,
     },
     /// Attach to an existing session
     Attach {
@@ -103,7 +106,9 @@ async fn main() -> Result<()> {
         None => tui::run().await,
         Some(Commands::Init) => cli::init::run().await,
         Some(Commands::Projects) => cli::projects::run().await,
-        Some(Commands::Spawn { name, note }) => cli::spawn::run(&name, note.as_deref()).await,
+        Some(Commands::Spawn { name, note, template }) => {
+            cli::spawn::run(&name, note.as_deref(), template.as_deref()).await
+        }
         Some(Commands::Attach { name }) => cli::attach::run(&name).await,
         Some(Commands::List) => cli::list::run().await,
         Some(Commands::Kill {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -113,4 +113,27 @@ impl SessionManager {
 
         Ok(())
     }
+
+    /// Send an initial prompt to the running session
+    pub fn send_prompt(&self, tmux_session: &str, prompt: &str) -> Result<()> {
+        for line in prompt.lines() {
+            let line = line.trim_end_matches('\r');
+            let mut args = vec!["send-keys", "-t", tmux_session];
+            if !line.is_empty() {
+                args.push(line);
+            }
+            args.push("Enter");
+
+            let status = Command::new("tmux")
+                .args(&args)
+                .status()
+                .context("Failed to send prompt to tmux session")?;
+
+            if !status.success() {
+                anyhow::bail!("tmux send-keys failed");
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -22,7 +22,7 @@ use std::process::Command;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::bank::{self, BankedItem};
-use crate::config::ProjectConfig;
+use crate::config::{ProjectConfig, TemplateConfig};
 use crate::confirm;
 use crate::db::{Database, Project, Session};
 use crate::disk;
@@ -467,6 +467,9 @@ pub async fn run() -> Result<()> {
                                         DisableMouseCapture
                                     )?;
 
+                                    let config = ProjectConfig::load(&project.path)?;
+                                    let template_name = prompt_template_selection(&config)?;
+
                                     print!("Session name: ");
                                     io::stdout().flush()?;
                                     let mut name = String::new();
@@ -485,8 +488,15 @@ pub async fn run() -> Result<()> {
                                             Some(note.to_string())
                                         };
 
-                                        let config = ProjectConfig::load(&project.path)?;
-                                        let sanitized = worktree::sanitize_branch_name(name);
+                                        let template = template_name
+                                            .as_ref()
+                                            .and_then(|name| config.templates.get(name));
+                                        let full_name = apply_template_prefix(
+                                            name,
+                                            template.and_then(|t| t.branch_prefix.as_deref()),
+                                        );
+                                        let sanitized =
+                                            worktree::sanitize_branch_name(&full_name);
 
                                         let branch_exists = std::process::Command::new("git")
                                             .args([
@@ -509,18 +519,19 @@ pub async fn run() -> Result<()> {
                                             )?
                                         } else {
                                             println!("Creating worktree '{sanitized}'...");
-                                            worktree::create(&project.path, name, &config)?
+                                            worktree::create(&project.path, &full_name, &config)?
                                         };
 
                                         println!("Starting Claude session...");
-                                        if !config.setup.is_empty() {
-                                            println!("Setup: {}", config.setup.join(" && "));
+                                        let setup = merge_setup(&config, template);
+                                        if !setup.is_empty() {
+                                            println!("Setup: {}", setup.join(" && "));
                                         }
                                         let tmux_session = app.session_manager.create(
                                             &project.name,
                                             &branch_name,
                                             &worktree_path,
-                                            &config.setup,
+                                            &setup,
                                         )?;
                                         app.db.add_session(
                                             project.id,
@@ -529,6 +540,22 @@ pub async fn run() -> Result<()> {
                                             &tmux_session,
                                             note.as_deref(),
                                         )?;
+                                        if let Some(prompt) = template
+                                            .and_then(|t| t.prompt.as_deref())
+                                            .map(str::trim)
+                                            .filter(|p| !p.is_empty())
+                                        {
+                                            std::thread::sleep(std::time::Duration::from_millis(
+                                                600,
+                                            ));
+                                            if let Err(err) =
+                                                app.session_manager.send_prompt(&tmux_session, prompt)
+                                            {
+                                                println!(
+                                                    "Warning: failed to send template prompt: {err}"
+                                                );
+                                            }
+                                        }
                                         println!("Session '{branch_name}' created.");
                                         std::thread::sleep(std::time::Duration::from_millis(500));
                                     }
@@ -1379,6 +1406,79 @@ fn format_note_excerpt(note: &str, max_len: usize) -> String {
     }
 
     excerpt
+}
+
+fn prompt_template_selection(config: &ProjectConfig) -> Result<Option<String>> {
+    if config.templates.is_empty() {
+        return Ok(None);
+    }
+
+    println!("Templates:");
+    for (idx, (name, template)) in config.templates.iter().enumerate() {
+        let mut details = Vec::new();
+        if let Some(prefix) = template.branch_prefix.as_deref().filter(|p| !p.is_empty()) {
+            details.push(format!("prefix {prefix}"));
+        }
+        if !template.setup.is_empty() {
+            details.push(format!("setup {}", template.setup.len()));
+        }
+        if template
+            .prompt
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .is_some()
+        {
+            details.push("prompt".to_string());
+        }
+
+        let detail_text = if details.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", details.join(", "))
+        };
+        println!("  {}. {}{}", idx + 1, name, detail_text);
+    }
+
+    print!("Template (enter to skip): ");
+    io::stdout().flush()?;
+    let mut selection = String::new();
+    io::stdin().read_line(&mut selection)?;
+    let selection = selection.trim();
+    if selection.is_empty() {
+        return Ok(None);
+    }
+
+    if let Ok(index) = selection.parse::<usize>() {
+        if index >= 1 && index <= config.templates.len() {
+            let name = config.templates.keys().nth(index - 1).cloned();
+            return Ok(name);
+        }
+    }
+
+    if config.templates.contains_key(selection) {
+        return Ok(Some(selection.to_string()));
+    }
+
+    println!("Unknown template '{selection}', continuing without template.");
+    Ok(None)
+}
+
+fn apply_template_prefix(name: &str, prefix: Option<&str>) -> String {
+    match prefix {
+        Some(prefix) if !prefix.is_empty() && !name.starts_with(prefix) => {
+            format!("{prefix}{name}")
+        }
+        _ => name.to_string(),
+    }
+}
+
+fn merge_setup(config: &ProjectConfig, template: Option<&TemplateConfig>) -> Vec<String> {
+    let mut setup = config.setup.clone();
+    if let Some(template) = template {
+        setup.extend(template.setup.clone());
+    }
+    setup
 }
 
 const LARGE_WORKTREE_BYTES: u64 = 1024 * 1024 * 1024;


### PR DESCRIPTION
## Summary
- add project template config for branch prefix, setup, and prompt
- allow selecting templates in TUI and via --template in CLI spawn
- send template prompt to the tmux session after spawn

## Testing
- cargo check

Closes #11